### PR TITLE
Add vpc_id as input to webcounter module

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -30,8 +30,8 @@ variable "wc_instance_type" {
   description = "The type of the webcounter VMs to create."
 }
 
-variable "wc_subnet_id" {
-  type        = string
+variable "wc_subnet_ids" {
+  type        = list
   default     = null
   description = "The subnet id in which to create the webcounter VMs."
 }

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "webcounter" {
   redis_password              = var.redis_password
   instance_count              = var.wc_instance_count
   instance_type               = var.wc_instance_type
-  subnet_id                   = var.wc_subnet_id
+  subnet_ids                   = var.wc_subnet_ids
   associate_public_ip_address = var.wc_associate_public_ip_address
 }
 

--- a/webcounter/input.tf
+++ b/webcounter/input.tf
@@ -35,10 +35,16 @@ variable "instance_type" {
   description = "The type of the webcounter VMs to create."
 }
 
+variable "vpc_id" {
+  type = string
+  default = null
+  description = "The VPC in which the machines will be created. Must be used together with subnet_ids."
+}
+
 variable "subnet_ids" {
   type        = list
   default     = null
-  description = "The subnet id in which to create the webcounter VMs."
+  description = "The subnet id in which to create the webcounter VMs. Must be used together with vpc_id."
 }
 
 variable "associate_public_ip_address" {

--- a/webcounter/security-group.tf
+++ b/webcounter/security-group.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "sg_default_webcounter" {
   name        = "webcounter-${formatdate("YYYYMMDDHHmmss", timestamp())}"
   description = "webcounter default access"
+  vpc_id = var.vpc_id != null ? var.vpc_id : null
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [name]


### PR DESCRIPTION
Allow the vpc id to be specified as input in the webcounter module. Update the security group to be created in this vpc.